### PR TITLE
fix: add legacy support for Node.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "lint": "eslint --ext .jsx,.js ./src",
-    "start": "react-scripts start",
+    "start": "react-scripts start --openssl-legacy-provider",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Added the `--openssl-legacy-provider` flag to the start script in `package.json`. This fix resolves compatibility issues with OpenSSL 3 in Node.js 17 and later, preventing startup errors during development.

- Issue: OpenSSL error in Node.js 17+ when running Webpack
- Solution: Enabling legacy OpenSSL provider for backward compatibility
- Impact: Allows seamless local development for contributors using newer Node.js versions
